### PR TITLE
Fix: Persist user session on iOS

### DIFF
--- a/src/lib/stores/authStore.ts
+++ b/src/lib/stores/authStore.ts
@@ -93,6 +93,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // Call the real login API
       const { token, user } = await authApi.login(email, password);
 
+      // Store token in secure storage for session persistence
+      await apiClient.setToken(token);
+
       // Store user data locally for offline access
       await SecureStore.setItemAsync(USER_KEY, JSON.stringify(user));
 
@@ -119,6 +122,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
       // After registration, automatically log them in
       const { token, user } = await authApi.login(data.email, data.password);
+
+      // Store token in secure storage for session persistence
+      await apiClient.setToken(token);
 
       // Store user data
       await SecureStore.setItemAsync(USER_KEY, JSON.stringify(user));
@@ -171,15 +177,20 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const token = await apiClient.getToken();
       const userJson = await SecureStore.getItemAsync(USER_KEY);
 
+      console.log('[Auth] Loading stored auth - token exists:', !!token, 'user exists:', !!userJson);
+
       if (token && userJson) {
         const user = JSON.parse(userJson) as User;
+        console.log('[Auth] Restoring session for user:', user.email);
         set({ user, token, isAuthenticated: true });
 
         // Optionally refresh user data in background
         get().refreshUser().catch(console.error);
+      } else {
+        console.log('[Auth] No stored session found');
       }
     } catch (error) {
-      console.error('Load stored auth error:', error);
+      console.error('[Auth] Load stored auth error:', error);
       // Clear potentially corrupted data
       await SecureStore.deleteItemAsync(TOKEN_KEY);
       await SecureStore.deleteItemAsync(USER_KEY);


### PR DESCRIPTION
## Summary
- Fix user session not persisting after closing the app on iOS
- Add explicit token storage in login/register functions
- Add debug logging for session restoration diagnostics

## Test plan
- [ ] Log in to the app
- [ ] Close the app completely (swipe up to kill)
- [ ] Reopen the app
- [ ] Verify user is still logged in

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small auth-state persistence change plus logging; low risk, though redundant token writes could mask issues if `authApi.login` semantics change.
> 
> **Overview**
> Ensures session persistence by explicitly saving the auth `token` via `apiClient.setToken()` during `login` and the post-registration auto-`login` flow in `authStore`.
> 
> Adds additional `[Auth]` debug logs and clearer error labeling in `loadStoredAuth` to help diagnose why a stored session does or doesn’t restore on app launch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8307e5485398232b4f975fbd8b1bc59321218c55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->